### PR TITLE
fix: increased chatbot iframe index to show on navbar top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import Highlight2 from "./components/Highlight2";
 import { getBrochureUrl } from "./helpers/utility";
 import { CHATBOT_URL } from "./constants";
 
+import "./index.css";
+
 function App() {
   const navbarItems: NavbarItem[] = [
     { label: "Home", redirectionUrl: "#home", sectionId: "home" },

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+:root {
+  --chatbot-z-index: 1500;
+}


### PR DESCRIPTION
Before:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d668a41c-bea7-484f-b9c3-00af137f8993">

After:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/35bd9231-d181-4d23-aebe-de7d41403344">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS variable for managing the stacking order of chatbot elements in the user interface.
- **Chores**
	- Added an import statement for the CSS file in the main application component, ensuring styles are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->